### PR TITLE
circular and deep object graphs

### DIFF
--- a/LeanMapper.Tests/AddingCustomMappings.cs
+++ b/LeanMapper.Tests/AddingCustomMappings.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace LeanMapper.Tests
 {
+    [Collection("MainCollection")]
     public class AddingCustomMappings
     {
         [Fact]

--- a/LeanMapper.Tests/BenchmarkTypes.cs
+++ b/LeanMapper.Tests/BenchmarkTypes.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace LeanMapper.Tests
 {
+    [Collection("MainCollection")]
     public class BenchmarkTypes
     {
         #region Object creation

--- a/LeanMapper.Tests/Classes/Child.cs
+++ b/LeanMapper.Tests/Classes/Child.cs
@@ -1,0 +1,9 @@
+﻿namespace LeanMapper.Tests.Classes
+{
+    public class Child
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Parent Parent { get; set; }
+    }
+}

--- a/LeanMapper.Tests/Classes/DtoChild.cs
+++ b/LeanMapper.Tests/Classes/DtoChild.cs
@@ -1,0 +1,9 @@
+﻿namespace LeanMapper.Tests.Classes
+{
+    public class DtoChild
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public DtoParent Parent { get; set; }
+    }
+}

--- a/LeanMapper.Tests/Classes/DtoParent.cs
+++ b/LeanMapper.Tests/Classes/DtoParent.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LeanMapper.Tests.Classes
+{
+    public class DtoParent
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public List<DtoChild> Children { get; set; }
+
+        public DtoParent()
+        {
+            Children = new List<DtoChild>();
+        }
+
+        public void AddChild(DtoChild child)
+        {
+            child.Parent = this;
+            Children.Add(child);
+        }
+    }
+}

--- a/LeanMapper.Tests/Classes/Parent.cs
+++ b/LeanMapper.Tests/Classes/Parent.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+namespace LeanMapper.Tests.Classes
+{
+    public class Parent 
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public IList<Child> Children { get; set; }
+
+        public Parent()
+        {
+            Children = new List<Child>();
+        }
+
+        public void AddChild(Child child)
+        {
+            child.Parent = this;
+            Children.Add(child);
+        }
+    }
+}

--- a/LeanMapper.Tests/CustomMappingInheritedProperties.cs
+++ b/LeanMapper.Tests/CustomMappingInheritedProperties.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace LeanMapper.Tests
 {
+    [Collection("MainCollection")]
     public class CustomMappingInheritedProperties
     {
         [Fact]

--- a/LeanMapper.Tests/LimitingDepthOfDeepGraphs.cs
+++ b/LeanMapper.Tests/LimitingDepthOfDeepGraphs.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LeanMapper.Tests.Classes;
+using Xunit;
+using static LeanMapper.Tests.Tools.ParentChildTools;
+
+namespace LeanMapper.Tests
+{
+    [Collection("MainCollection")]
+    public class LimitingDepthOfDeepGraphs
+    {
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(0, 1)]
+        [InlineData(0, 2)]
+        [InlineData(0, 10)]
+        [InlineData(1, 10)]
+        [InlineData(2, 10)]
+        [InlineData(10, 10)]
+        [InlineData(11, 10)]
+        [InlineData(12, 10)]
+        [InlineData(13, 10)]
+        public void GraphLimitedByMaxDepth(int maxDepth, int graphDepth)
+        {
+            Mapper.Reset();
+            Mapper.Config<Parent, DtoParent>()
+                .SetDepth(maxDepth);
+            var parent0 = GetParent(0);
+            var dto = Mapper.Map<Parent, DtoParent>(parent0);
+            var actualResult = GetDepth(dto);
+            Assert.Equal(maxDepth, actualResult);
+        }
+    }
+}

--- a/LeanMapper.Tests/MappingConfigurations.cs
+++ b/LeanMapper.Tests/MappingConfigurations.cs
@@ -81,6 +81,7 @@ namespace LeanMapper.Tests
 
     #endregion
 
+    [Collection("MainCollection")]
     public class MappingConfigurations
     {
         [Fact]

--- a/LeanMapper.Tests/MappingEntitiesWithCircularGraph.cs
+++ b/LeanMapper.Tests/MappingEntitiesWithCircularGraph.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LeanMapper.Tests.Classes;
+using Xunit;
+using static LeanMapper.Tests.Tools.ParentChildTools;
+
+namespace LeanMapper.Tests
+{
+    [Collection("MainCollection")]
+    public class MappingEntitiesWithCircularGraph
+    {
+        [Fact]
+        public void ConvertParentWithChildrenNotNull()
+        {
+            var parent = GetParent();
+            var dto = Mapper.Map<Parent, DtoParent>(parent);
+            Assert.NotNull(dto);
+        }
+
+        [Fact]
+        public void ConvertParentWithChildrenHasSameNumberOfChildren()
+        {
+            var parent = GetParent();
+            var dto = Mapper.Map<Parent, DtoParent>(parent);
+            Assert.Equal(parent.Children.Count, dto.Children.Count);
+        }
+
+        [Fact]
+        public void ConvertParentWithNoChildrenNotNull()
+        {
+            var parent = GetParent();
+            parent.Children.Clear();
+            var dto = Mapper.Map<Parent, DtoParent>(parent);
+            Assert.NotNull(dto);
+        }
+
+        [Fact]
+        public void ConvertParentWithNoChildrenHasSameNumberOfChildren()
+        {
+            var parent = GetParent();
+            parent.Children.Clear();
+            var dto = Mapper.Map<Parent, DtoParent>(parent);
+            Assert.Equal(parent.Children.Count, dto.Children.Count);
+        }
+
+        [Fact]
+        public void ConvertParentWithChildrenEqual()
+        {
+            var parent = GetParent();
+            var dto = Mapper.Map<Parent, DtoParent>(parent);
+            Assert.True(AreEqual(parent, dto));
+        }
+
+        [Fact]
+        public void ConvertParentWithNoChildrenEqual()
+        {
+            var parent = GetParent();
+            parent.Children.Clear();
+            var dto = Mapper.Map<Parent, DtoParent>(parent);
+            Assert.True(AreEqual(parent, dto));
+        }
+
+    }
+}

--- a/LeanMapper.Tests/MappingEntityWithOnlyPrimitives.cs
+++ b/LeanMapper.Tests/MappingEntityWithOnlyPrimitives.cs
@@ -2,6 +2,7 @@
 
 namespace LeanMapper.Tests
 {
+    [Collection("MainCollection")]
     public class MappingEntityWithOnlyPrimitives
     {
         #region Classes

--- a/LeanMapper.Tests/MappingEnums.cs
+++ b/LeanMapper.Tests/MappingEnums.cs
@@ -38,6 +38,7 @@ namespace LeanMapper.Tests
 
     #endregion
 
+    [Collection("MainCollection")]
     public class MappingEnums
     {
         [Fact]

--- a/LeanMapper.Tests/MappingPrimitives.cs
+++ b/LeanMapper.Tests/MappingPrimitives.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace LeanMapper.Tests
 {
+    [Collection("MainCollection")]
     public class MappingPrimitives
     {
         [Fact]

--- a/LeanMapper.Tests/Tools/MainFixture.cs
+++ b/LeanMapper.Tests/Tools/MainFixture.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using LeanMapper.Tests.Classes;
+using Xunit;
+
+namespace LeanMapper.Tests.Tools
+{
+    public class MainFixture : IDisposable
+    {
+        /// <summary>
+        /// This code will run _once_ before any tests in the MainCollection are run.
+        /// </summary>
+        public MainFixture()
+        {
+            Mapper.Config<Parent, DtoParent>()
+                .SetDepth(8);
+        }
+
+
+        /// <summary>
+        /// This code will run _once_ after all of the tests in the MainCollection have completed.
+        /// </summary>
+        public void Dispose()
+        {
+            //
+        }
+    }
+
+    [CollectionDefinition("MainCollection")]
+    public class MainFixtureCollection : ICollectionFixture<MainFixture>
+    {
+        // This class has no code, and is never created. Its purpose is simply
+        // to be the place to apply [CollectionDefinition] and all the
+        // ICollectionFixture<> interfaces.        
+    }
+}

--- a/LeanMapper.Tests/Tools/ParentChildTools.cs
+++ b/LeanMapper.Tests/Tools/ParentChildTools.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LeanMapper.Tests.Classes;
+using Xunit;
+
+namespace LeanMapper.Tests.Tools
+{
+    public static class ParentChildTools
+    {
+        public static Parent GetParent(int id = 0)
+        {
+            var parent = new Parent()
+            {
+                Id = id + 2,
+                Name = "Parent0"
+            };
+
+            var child1 = new Child()
+            {
+                Id = id + 0,
+                Name = $"Child{id + 0}"
+            };
+
+            var child2 = new Child()
+            {
+                Id = id + 1,
+                Name = $"Child{id + 1}"
+            };
+
+            parent.AddChild(child1);
+            parent.AddChild(child2);
+
+            return parent;
+        }
+
+        public static int GetDepth(Parent parent)
+        {
+            return parent.Children.Any() ? parent.Children.Max(GetDepth) + 1 : 0;
+        }
+
+        public static  int GetDepth(Child child)
+        {
+            var result = child.Parent != null ? GetDepth(child.Parent) + 1 : 0;
+            return result;
+        }
+
+        public static int GetDepth(DtoParent parent)
+        {
+            return parent.Children.Any() ? parent.Children.Max(GetDepth) + 1 : 0;
+        }
+
+        public static int GetDepth(DtoChild child)
+        {
+            var result = child.Parent != null ? GetDepth(child.Parent) + 1 : 0;
+            return result;
+        }
+        public static Parent CreateGraph(int depth)
+        {
+            var newParent = GetParent();
+            CreateDepth(newParent, depth);
+            return newParent;
+        }
+
+        public static void CreateDepth(Parent parent, int depth)
+        {
+            if (depth == 0)
+            {
+                parent.Children.Clear();
+            }
+            else if (depth == 1)
+            {
+                parent.Children[0].Parent = null;
+                parent.Children[1].Parent = null;
+            }
+            else if (depth > 1)
+            {
+                var newParent = GetParent(parent.Id + 1);
+                CreateDepth(newParent, depth - 2);
+                parent.Children[0].Parent = newParent;
+                parent.Children[1].Parent = null;
+            }
+
+        }
+
+        public static bool AreEqual(Parent parent, DtoParent dtoParent)
+        {
+            return dtoParent.Id == parent.Id && dtoParent.Name == parent.Name && parent.Children.Zip(dtoParent.Children, AreEqual).All(x => x);
+        }
+
+        public static bool AreEqual(Child child, DtoChild dtoChild)
+        {
+            return dtoChild.Id == child.Id && dtoChild.Name == child.Name;
+
+        }
+
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(10)]
+        public static void CreateDepthMatchesGetDepth(int depth)
+        {
+            var parent0 = CreateGraph(depth);
+            var expectedResult = depth;
+            var actualResult = GetDepth(parent0);
+            Assert.Equal(actualResult, expectedResult);
+        }
+
+    }
+}

--- a/LeanMapper/MappingConfigBase.cs
+++ b/LeanMapper/MappingConfigBase.cs
@@ -8,6 +8,8 @@ namespace LeanMapper
         protected readonly List<string> Ignored;
         protected readonly Dictionary<string, Expression> MappingFunctions;
 
+        protected int depth = Mapper.MaxDepth;
+
         protected MappingConfigBase()
         {
             Ignored = new List<string>();
@@ -27,6 +29,11 @@ namespace LeanMapper
         internal Expression GetMapping(string propertyName)
         {
             return MappingFunctions[propertyName];
+        }
+
+        internal int GetDepth()
+        {
+            return depth;
         }
     }
 }

--- a/LeanMapper/Mappingconfig.cs
+++ b/LeanMapper/Mappingconfig.cs
@@ -62,5 +62,11 @@ namespace LeanMapper
 
             return propertyName;
         }
+
+        public MappingConfig<TSrc, TDest> SetDepth(int newDepth)
+        {
+            this.depth = newDepth;
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Added global MaxDepth property to Mapper static class.
Added Reset() method to Mapper static class.
Added stack count and loop interrupt to Mapper.BuildInitializerBlock() method.
Added GetPublicProperties() method to Mapper static class. This method builds a collection of PropertyInfo for the properties of a type including properties on inherited interfaces.
Added SetDepth() method to MappingConfig<TSrc, TDest> class.
Added GetDepth() method to MappingConfigBase class.
Added "Collection" to test suite with initializer for collection.
Added tests to test limiting the depth of a deep object graph.
Added tests to test entities with circular graphs.
Added Parent, Child, DtoParent, DtoChild classes for testing circular and deep object graphs.
Added tools for building and verifying depth of object graphs.
Added test for verifying the accuracy of the depth checking tool.